### PR TITLE
upgraded NPgSQL package to 2.2.7 to handle postgres 9.4

### DIFF
--- a/DataTableWriter/packages.config
+++ b/DataTableWriter/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="CsvHelper" version="2.13.2.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Npgsql" version="2.2.5" targetFramework="net45" />
+  <package id="Npgsql" version="2.2.7" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The older versions of the NPgSQL package were throwing errors when connecting to a recent postgres release