### PR TITLE
Fixing WiX toolset version mismatches

### DIFF
--- a/TabMonServiceInstallerBootstrapper/Bundle.wxs
+++ b/TabMonServiceInstallerBootstrapper/Bundle.wxs
@@ -16,7 +16,7 @@
 <?define PostgresPassword = "password"?>
 <?define PostgresPortNumber = "5432"?>
 
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+<Wix RequiredVersion="3.9.1208.0" xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:bal="http://schemas.microsoft.com/wix/BalExtension"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Bundle Name="$(var.ApplicationName)" Version="$(bal.Version($(var.ProductVersion)))" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.ProductUpgradeCode)" IconSourceFile="$(var.IconFile)" AboutUrl="$(var.AboutURL)">

--- a/TabMonServiceInstallerDBInitializer/TabMonServiceInstallerDBInitializer.wixproj
+++ b/TabMonServiceInstallerDBInitializer/TabMonServiceInstallerDBInitializer.wixproj
@@ -34,6 +34,11 @@
       <Name>PowerShellWixExtension</Name>
     </WixExtension>
   </ItemGroup>
+  <PropertyGroup>
+      <WixToolPath>..\lib\wix\3.9\</WixToolPath>
+      <WixTargetsPath>$(WixToolPath)Wix.targets</WixTargetsPath>
+      <WixTasksPath>wixtasks.dll</WixTasksPath>
+  </PropertyGroup>
   <Import Project="$(WixTargetsPath)" />
   <PropertyGroup>
     <PostBuildEvent>if not exist "$(SolutionDir)TabMonServiceInstallerBootstrapper\Installers\" mkdir "$(SolutionDir)TabMonServiceInstallerBootstrapper\Installers\"


### PR DESCRIPTION
This PR fixes some version mismatch issues in the WiX toolset that could cause installer issues under certain circumstances.

We resolve the issues by doing two things:
1) Assert that the RequiredVersion attribute in the Wix element in the bootstrapper matches the version of the toolset that we bundle.
2) Specify that the TabMonServiceInstallerDBInitializer project uses the local bundled Wix toolset instead of whatever the global default is.