### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ TabMon.v12.suo
 TabMonConfigSectionGenerator/bin/
 TabMonServiceInstaller/Generated/
 *.user
+docs/Gemfile.lock
+docs/_site


### PR DESCRIPTION
Adding docs/Gemfile.lock so we don't get vulnerability issues in the future. 
Adding docs/_site - which only used in local builds of GitHub pages, so doesn't need to be here.